### PR TITLE
Prevent error when min bond is not a valid number

### DIFF
--- a/packages/frontend/src/creation-form/index.tsx
+++ b/packages/frontend/src/creation-form/index.tsx
@@ -151,6 +151,7 @@ export const Component = ({
                     kpiToken.expiration
                 )) &&
             minimumBond &&
+            !isNaN(Number(minimumBond)) &&
             openingTimestamp.isAfter(dayjs())
         ) {
             const formattedMinimumBond = ethers.utils.parseUnits(

--- a/packages/frontend/src/page/components/answer-form/index.tsx
+++ b/packages/frontend/src/page/components/answer-form/index.tsx
@@ -127,7 +127,7 @@ export const AnswerForm = ({
         : question.bond.mul(2);
 
     const finalBond = useMemo(() => {
-        return !!bond && !!bond.value && !isNaN(Number(bond.value))
+        return !!bond && !!bond.value && !isNaN(parseInt(bond.value))
             ? utils.parseUnits(bond.value, chain?.nativeCurrency.decimals)
             : BigNumber.from("0");
     }, [bond, chain?.nativeCurrency.decimals]);
@@ -342,7 +342,9 @@ export const AnswerForm = ({
             setBond(value);
 
             const parsedBond = utils.parseUnits(
-                value.value && !isNaN(Number(value.value)) ? value.value : "0",
+                value.value && !isNaN(parseInt(value.value))
+                    ? value.value
+                    : "0",
                 chain?.nativeCurrency.decimals
             );
             let bondErrorText = "";

--- a/packages/frontend/src/page/components/answer-form/index.tsx
+++ b/packages/frontend/src/page/components/answer-form/index.tsx
@@ -127,7 +127,7 @@ export const AnswerForm = ({
         : question.bond.mul(2);
 
     const finalBond = useMemo(() => {
-        return !!bond && !!bond.value
+        return !!bond && !!bond.value && !isNaN(Number(bond.value))
             ? utils.parseUnits(bond.value, chain?.nativeCurrency.decimals)
             : BigNumber.from("0");
     }, [bond, chain?.nativeCurrency.decimals]);
@@ -342,7 +342,7 @@ export const AnswerForm = ({
             setBond(value);
 
             const parsedBond = utils.parseUnits(
-                value.value || "0",
+                value.value && !isNaN(Number(value.value)) ? value.value : "0",
                 chain?.nativeCurrency.decimals
             );
             let bondErrorText = "";


### PR DESCRIPTION
Fixes https://github.com/carrot-kpi/erc20-kpi-token-template/issues/89.
Adding a `.` as minimum bond (when all the other fields are valorized) causes the creation form to crash.
This PR handles this case.